### PR TITLE
Add hints usage feature

### DIFF
--- a/src/atoms/HintButton/HintButton.tsx
+++ b/src/atoms/HintButton/HintButton.tsx
@@ -2,12 +2,14 @@ import { Tooltip, IconButton } from "@mui/material"
 import React, { FC } from "react"
 import TipsAndUpdatesIcon from "@mui/icons-material/TipsAndUpdates"
 
-export const HintButton: FC<Props> = ({ disabled, onClick }) => {
+export const HintButton: FC<Props> = ({ disabled, onClick, hintsLeft }) => {
+  const disabledTitle =
+    hintsLeft !== 0
+      ? "You can only use one hint per round"
+      : "You have used maximum available hints per game"
   return (
     <Tooltip
-      title={
-        disabled ? "You can only use one hint per round" : "Give me a hint"
-      }
+      title={disabled ? `${disabledTitle}` : "Give me a hint"}
       placement="top"
       arrow
     >
@@ -31,4 +33,5 @@ export const HintButton: FC<Props> = ({ disabled, onClick }) => {
 export interface Props {
   disabled: boolean
   onClick: () => void
+  hintsLeft: number
 }

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -35,9 +35,10 @@ export const Game: FC<Props> = ({
   lang,
   choices,
   onClickNext,
-  onClicLeave,
+  onClickLeave,
   onAnswer,
   error,
+  hintsLeft,
 }) => {
   const maxScore = useMemo(() => {
     if (!players || players.length < 2) return user?.displayName
@@ -106,7 +107,12 @@ export const Game: FC<Props> = ({
 
             {lang && gameStatus === "started" && (
               <Box sx={{ my: 2 }}>
-                <Round lang={lang} choices={choices} onAnswer={onAnswer} />
+                <Round
+                  lang={lang}
+                  choices={choices}
+                  onAnswer={onAnswer}
+                  hintsLeft={hintsLeft}
+                />
                 <Divider sx={{ my: 3 }} />
               </Box>
             )}
@@ -162,10 +168,10 @@ export const Game: FC<Props> = ({
         )}
 
         <Button
-          variant="outlined"
-          color="error"
-          sx={{ mt: 2 }}
-          onClick={onClicLeave}
+          variant="contained"
+          color="primary"
+          sx={{ mt: 1 }}
+          onClick={onClickLeave}
           endIcon={<ExitToAppIcon />}
         >
           {challenge?.id ? "Leave" : "Return"}
@@ -182,10 +188,11 @@ interface Props {
   challenge: any
   players?: any[]
   onClickNext: () => void
-  onClicLeave: () => void
+  onClickLeave: () => void
   showAnswer: boolean
   lang: any
   choices?: any[]
   onAnswer: (answer: any) => void
   error?: string
+  hintsLeft: number
 }

--- a/src/components/Round/Round.tsx
+++ b/src/components/Round/Round.tsx
@@ -9,6 +9,7 @@ import { WorldDiagram } from "../../icons/worldDiagram"
 import { Timer } from "../../atoms/Timer/Timer"
 import { LanguageInfo } from "../../molecules/LanguageInfo/LanguageInfo"
 import { HintButton } from "../../atoms/HintButton/HintButton"
+import { maxHints } from "../../utils/constants"
 
 export const BoxContainer = styled("div")`
   display: flex;
@@ -18,7 +19,7 @@ export const BoxContainer = styled("div")`
   width: 100%;
 `
 
-export const Round: FC<Props> = ({ lang, choices, onAnswer }) => {
+export const Round: FC<Props> = ({ lang, choices, onAnswer, hintsLeft }) => {
   const [langInfo, setLangInfo] = useState<any>()
   const [showInfo, setShowInfo] = useState<boolean>(false)
   const [showHint, setShowHint] = useState<boolean>(false)
@@ -63,7 +64,7 @@ export const Round: FC<Props> = ({ lang, choices, onAnswer }) => {
 
   useEffect(() => {
     if (!answer) return
-    onAnswer(answer, time)
+    onAnswer(answer, time, showHint)
     setShowHint(false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [answer])
@@ -75,6 +76,10 @@ export const Round: FC<Props> = ({ lang, choices, onAnswer }) => {
   const onActive = () => {
     setActive(true)
   }
+
+  const hintsText = `${hintsLeft - 1 !== 0 ? hintsLeft - 1 : "no"} ${
+    hintsLeft - 1 === 1 ? "hint" : "hints"
+  }`
 
   return (
     <Container>
@@ -97,7 +102,11 @@ export const Round: FC<Props> = ({ lang, choices, onAnswer }) => {
       <BoxContainer>
         <Waveform url={langUrl} onActive={onActive} />
         {!answer && active && (
-          <HintButton disabled={showHint} onClick={() => setShowHint(true)} />
+          <HintButton
+            disabled={hintsLeft === 0 || showHint}
+            onClick={() => setShowHint(true)}
+            hintsLeft={hintsLeft}
+          />
         )}
       </BoxContainer>
       {choices &&
@@ -116,10 +125,21 @@ export const Round: FC<Props> = ({ lang, choices, onAnswer }) => {
             )
         )}
       {langInfo && showHint && (
-        <Alert sx={{ mt: 2 }} severity="info">
-          {hint}
+        <Alert sx={{ mt: 2, textAlign: "left" }} severity="info">
+          <Typography sx={{ mb: 1 }} variant="body2">
+            {hint}
+          </Typography>
+          <Typography
+            sx={{ fontWeight: 500 }}
+            color="primary.light"
+            variant="caption"
+          >
+            Using hints is limited to {maxHints} per game and deducts your round
+            score by half. You have {hintsText} available.
+          </Typography>
         </Alert>
       )}
+
       {answer && (
         <>
           <Alert
@@ -156,5 +176,6 @@ export const Round: FC<Props> = ({ lang, choices, onAnswer }) => {
 interface Props {
   lang: any
   choices?: any[]
-  onAnswer: (answer: any, time?: number) => void
+  onAnswer: (answer: any, time?: number, showHint?: boolean) => void
+  hintsLeft: number
 }

--- a/src/hooks/useChallenge.tsx
+++ b/src/hooks/useChallenge.tsx
@@ -35,9 +35,6 @@ export const useChallenge = (gameId?: string) => {
             setError(undefined)
           }
           dispatch(setChallenge({ id: gameId, ...challengeData }))
-          if (subscribePlayers) {
-            subscribePlayers()
-          }
           subscribePlayers = firebase
             .firestore()
             .collection(`challenges/${gameId}/players`)
@@ -61,7 +58,7 @@ export const useChallenge = (gameId?: string) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gameId, challenge?.id])
 
-  const writeScore = (score: Score, turn: number) => {
+  const writeScore = (score: Score, turn: number, hintsUsed: number) => {
     if (!user) {
       return
     }
@@ -76,6 +73,7 @@ export const useChallenge = (gameId?: string) => {
         photoURL: user.photoURL || "",
         joinedAt: firebase.firestore.FieldValue.serverTimestamp(),
         score,
+        hintsUsed,
         turn,
       })
       .then(() => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,6 +2,8 @@ import { UserSettings } from "../types/user"
 
 export const maxLevels = 5
 
+export const maxHints = 3
+
 export type ChallengeStatus = "pending" | "started" | "finished" | "aborted"
 
 export const defaultUserSettings: UserSettings = {}


### PR DESCRIPTION
- Only `3` hints per game is allowed
- The `hintsUsed` value is stored in the database
- `50%` of the current round score after using a hint is deducted
- Hints usage caption is added beneath the hint