### PR TITLE
Hide unnecessary setup fields for single player mode

### DIFF
--- a/cypress/integration/MainMenu.spec.tsx
+++ b/cypress/integration/MainMenu.spec.tsx
@@ -15,7 +15,6 @@ describe("Main Menu", () => {
 
   it("Starts with correct setup for single player", () => {
     cy.get(`[aria-label="single player"]`).click()
-    cy.get(`[aria-label="players"] input`).should("have.value", "1")
     cy.get(`[aria-label="rounds"] input`).should("have.value", "10")
     cy.get(`[aria-label="level"] input[checked]`).should("have.value", "1")
   })

--- a/src/components/MainMenu/MainMenu.tsx
+++ b/src/components/MainMenu/MainMenu.tsx
@@ -33,6 +33,7 @@ export var MainMenu: FC<Props> = function (props) {
 
   const [openSetupDialog, setOpenSetupDialog] = useState(false)
   const [openChallengeLinkDialog, setOpenChallengeLinkDialog] = useState(false)
+  const [isSinglePlayer, setIsSinglePlayer] = useState<boolean>(false)
 
   const dispatch = useDispatch()
 
@@ -73,10 +74,12 @@ export var MainMenu: FC<Props> = function (props) {
 
   const onClickSinglePlayer = () => {
     setInitialSetup({ ...defaultChallengeSetup })
+    setIsSinglePlayer(true)
   }
 
   const onClickMultiplayer = () => {
     setInitialSetup({ ...defaultChallengeSetup, players: 2 })
+    setIsSinglePlayer(false)
   }
 
   const onStartChallenge = () => {
@@ -126,6 +129,7 @@ export var MainMenu: FC<Props> = function (props) {
           setup={initialSetup}
           open={openSetupDialog}
           onClose={onCreateGame}
+          isSinglePlayer={isSinglePlayer}
         />
       )}
       {challenge && (

--- a/src/components/MainMenu/MainMenu.tsx
+++ b/src/components/MainMenu/MainMenu.tsx
@@ -33,7 +33,6 @@ export var MainMenu: FC<Props> = function (props) {
 
   const [openSetupDialog, setOpenSetupDialog] = useState(false)
   const [openChallengeLinkDialog, setOpenChallengeLinkDialog] = useState(false)
-  const [isSinglePlayer, setIsSinglePlayer] = useState<boolean>(false)
 
   const dispatch = useDispatch()
 
@@ -74,12 +73,10 @@ export var MainMenu: FC<Props> = function (props) {
 
   const onClickSinglePlayer = () => {
     setInitialSetup({ ...defaultChallengeSetup })
-    setIsSinglePlayer(true)
   }
 
   const onClickMultiplayer = () => {
     setInitialSetup({ ...defaultChallengeSetup, players: 2 })
-    setIsSinglePlayer(false)
   }
 
   const onStartChallenge = () => {
@@ -129,7 +126,6 @@ export var MainMenu: FC<Props> = function (props) {
           setup={initialSetup}
           open={openSetupDialog}
           onClose={onCreateGame}
-          isSinglePlayer={isSinglePlayer}
         />
       )}
       {challenge && (

--- a/src/molecules/ChallengeSetupDialog/ChallengeSetupDialog.tsx
+++ b/src/molecules/ChallengeSetupDialog/ChallengeSetupDialog.tsx
@@ -20,7 +20,6 @@ import { ChallengeSetup } from "../../types/challenge"
 import { useMemo } from "react"
 
 export interface LevelDialogProps {
-  isSinglePlayer: boolean
   open: boolean
   setup?: ChallengeSetup
   onClose: (setup?: ChallengeSetup) => void
@@ -65,7 +64,7 @@ export function ChallengeSetupDialog(props: LevelDialogProps) {
       <Container maxWidth="xs">
         <Typography variant="subtitle1">Choose your setup</Typography>
         <form onSubmit={formik.handleSubmit}>
-          {!props.isSinglePlayer && (
+          {setup?.players !== 1 && (
             <>
               <Box sx={{ my: 1 }}>
                 <ButtonGroup aria-label="outlined button group">

--- a/src/molecules/ChallengeSetupDialog/ChallengeSetupDialog.tsx
+++ b/src/molecules/ChallengeSetupDialog/ChallengeSetupDialog.tsx
@@ -20,6 +20,7 @@ import { ChallengeSetup } from "../../types/challenge"
 import { useMemo } from "react"
 
 export interface LevelDialogProps {
+  isSinglePlayer: boolean
   open: boolean
   setup?: ChallengeSetup
   onClose: (setup?: ChallengeSetup) => void
@@ -64,39 +65,43 @@ export function ChallengeSetupDialog(props: LevelDialogProps) {
       <Container maxWidth="xs">
         <Typography variant="subtitle1">Choose your setup</Typography>
         <form onSubmit={formik.handleSubmit}>
-          <Box sx={{ my: 1 }}>
-            <ButtonGroup aria-label="outlined button group">
-              <Button
-                variant={formik.values.live ? "contained" : "outlined"}
-                onClick={() => formik.setFieldValue("live", true)}
-              >
-                Live
-              </Button>
-              <Button
-                variant={!formik.values.live ? "contained" : "outlined"}
-                onClick={() => formik.setFieldValue("live", false)}
-              >
-                Private
-              </Button>
-            </ButtonGroup>
-          </Box>
-          <Typography color="primary" variant="caption">
-            {liveHelpMessage}
-          </Typography>
-          <TextField
-            error={Boolean(formik.touched.players && formik.errors.players)}
-            helperText={formik.touched.players && formik.errors.players}
-            fullWidth
-            label="Players"
-            margin="normal"
-            name="players"
-            aria-label="players"
-            onBlur={formik.handleBlur}
-            onChange={formik.handleChange}
-            value={formik.values.players}
-            variant="outlined"
-            type="number"
-          />
+          {!props.isSinglePlayer && (
+            <>
+              <Box sx={{ my: 1 }}>
+                <ButtonGroup aria-label="outlined button group">
+                  <Button
+                    variant={formik.values.live ? "contained" : "outlined"}
+                    onClick={() => formik.setFieldValue("live", true)}
+                  >
+                    Live
+                  </Button>
+                  <Button
+                    variant={!formik.values.live ? "contained" : "outlined"}
+                    onClick={() => formik.setFieldValue("live", false)}
+                  >
+                    Private
+                  </Button>
+                </ButtonGroup>
+              </Box>
+              <Typography color="primary" variant="caption">
+                {liveHelpMessage}
+              </Typography>
+              <TextField
+                error={Boolean(formik.touched.players && formik.errors.players)}
+                helperText={formik.touched.players && formik.errors.players}
+                fullWidth
+                label="Players"
+                margin="normal"
+                name="players"
+                aria-label="players"
+                onBlur={formik.handleBlur}
+                onChange={formik.handleChange}
+                value={formik.values.players}
+                variant="outlined"
+                type="number"
+              />
+            </>
+          )}
           <TextField
             error={Boolean(formik.touched.rounds && formik.errors.rounds)}
             helperText={formik.touched.rounds && formik.errors.rounds}


### PR DESCRIPTION
When opening single player setup dialog:

- players input is hidden
- mode buttons (live, private) are hidden