### PR TITLE
add time limit to the round

### DIFF
--- a/src/components/Round/Round.tsx
+++ b/src/components/Round/Round.tsx
@@ -71,6 +71,10 @@ export const Round: FC<Props> = ({ lang, choices, onAnswer, hintsLeft }) => {
 
   const onTimerChange = (t: number) => {
     setTime(t)
+    if (t === 30) {
+      setActive(false)
+      setAnswer(" ")
+    }
   }
 
   const onActive = () => {
@@ -81,14 +85,17 @@ export const Round: FC<Props> = ({ lang, choices, onAnswer, hintsLeft }) => {
     hintsLeft - 1 === 1 ? "hint" : "hints"
   }`
 
+  const timeColor =
+    time >= 25
+      ? "error.light"
+      : time >= 20
+      ? "warning.light"
+      : "secondary.light"
+
   return (
     <Container>
       <Box sx={{ mb: 2 }}>
-        <Typography
-          color="secondary.light"
-          variant="h2"
-          sx={{ textAlign: "center" }}
-        >
+        <Typography color={timeColor} variant="h2" sx={{ textAlign: "center" }}>
           <Timer onTimeChange={onTimerChange} active={active} />
         </Typography>
         <Typography


### PR DESCRIPTION
- The round time is limited to `30` seconds
- Time is shown in **orange** color after `20` seconds
- Time is shown in **red** color after `25` seconds
- Time is checked within `onTimerChange`
- When the time runs out, an empty string is assigned to `asnwer` which is treated as a wrong answer, and the `Next` button is shown
- Manual test case is added to the [spreadsheet](https://docs.google.com/spreadsheets/d/1bfFrEOOUulLGaZTeHJjW62BI0UeyGGayOMGzeVReHUk/edit#gid=1307178696)