### PR TITLE
add radio buttons for rounds selection

### DIFF
--- a/cypress/integration/MainMenu.spec.tsx
+++ b/cypress/integration/MainMenu.spec.tsx
@@ -15,14 +15,14 @@ describe("Main Menu", () => {
 
   it("Starts with correct setup for single player", () => {
     cy.get(`[aria-label="single player"]`).click()
-    cy.get(`[aria-label="rounds"] input`).should("have.value", "10")
+    cy.get(`[aria-label="rounds"] input[checked]`).should("have.value", "10")
     cy.get(`[aria-label="level"] input[checked]`).should("have.value", "1")
   })
 
   it("Starts with correct setup for multiplayer", () => {
     cy.get(`[aria-label="multi player"]`).click()
     cy.get(`[aria-label="players"] input`).should("have.value", "2")
-    cy.get(`[aria-label="rounds"] input`).should("have.value", "10")
+    cy.get(`[aria-label="rounds"] input[checked]`).should("have.value", "10")
     cy.get(`[aria-label="level"] input[checked]`).should("have.value", "1")
   })
 })

--- a/cypress/integration/MainMenu.spec.tsx
+++ b/cypress/integration/MainMenu.spec.tsx
@@ -15,14 +15,20 @@ describe("Main Menu", () => {
 
   it("Starts with correct setup for single player", () => {
     cy.get(`[aria-label="single player"]`).click()
-    cy.get(`[aria-label="rounds"] input[checked]`).should("have.value", "10")
+    cy.get(`[aria-label="rounds-controller"] input[checked]`).should(
+      "have.value",
+      "10"
+    )
     cy.get(`[aria-label="level"] input[checked]`).should("have.value", "1")
   })
 
   it("Starts with correct setup for multiplayer", () => {
     cy.get(`[aria-label="multi player"]`).click()
     cy.get(`[aria-label="players"] input`).should("have.value", "2")
-    cy.get(`[aria-label="rounds"] input[checked]`).should("have.value", "10")
+    cy.get(`[aria-label="rounds-controller"] input[checked]`).should(
+      "have.value",
+      "10"
+    )
     cy.get(`[aria-label="level"] input[checked]`).should("have.value", "1")
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,6 @@ const firebaseAppAuth = firebase.auth()
 
 const googleProvider = new firebase.auth.GoogleAuthProvider()
 googleProvider.addScope("https://www.googleapis.com/auth/user.birthday.read")
-
 const facebookProvider = new firebase.auth.FacebookAuthProvider()
 
 const providers = {

--- a/src/molecules/ChallengeSetupDialog/ChallengeSetupDialog.tsx
+++ b/src/molecules/ChallengeSetupDialog/ChallengeSetupDialog.tsx
@@ -127,7 +127,7 @@ export function ChallengeSetupDialog(props: LevelDialogProps) {
             <RadioGroup
               row
               name="rounds"
-              aria-label="rounds"
+              aria-label="rounds-controller"
               value={roundsController}
               onChange={(e) => setRoundsController(e.target.value)}
             >

--- a/src/molecules/ChallengeSetupDialog/ChallengeSetupDialog.tsx
+++ b/src/molecules/ChallengeSetupDialog/ChallengeSetupDialog.tsx
@@ -17,7 +17,7 @@ import { useFormik } from "formik"
 import * as Yup from "yup"
 import { Box } from "@mui/system"
 import { ChallengeSetup } from "../../types/challenge"
-import { useMemo } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 
 export interface LevelDialogProps {
   open: boolean
@@ -26,7 +26,7 @@ export interface LevelDialogProps {
 }
 
 const LEVELS_COUNT = 5
-const ROUNDS_ARRAY = [5, 10, 15, 20]
+const ROUNDS_ARRAY = [5, 10, 15]
 
 export function ChallengeSetupDialog(props: LevelDialogProps) {
   const { onClose, setup, open } = props
@@ -59,8 +59,28 @@ export function ChallengeSetupDialog(props: LevelDialogProps) {
     [formik]
   )
 
+  const [roundsController, setRoundsController] = useState<number | string>(10)
+  const [customRoundsInput, setCustomRoundsInput] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (roundsController === "custom") {
+      setCustomRoundsInput(true)
+      formik.setFieldValue("rounds", 10)
+    } else {
+      setCustomRoundsInput(false)
+      formik.setFieldValue("rounds", roundsController)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [roundsController])
+
   return (
-    <Dialog onClose={handleClose} aria-label={"Challenge Setup"} open={open}>
+    <Dialog
+      onClose={handleClose}
+      aria-label={"Challenge Setup"}
+      open={open}
+      fullWidth
+      maxWidth="xs"
+    >
       <DialogTitle>New Game</DialogTitle>
       <Container maxWidth="xs">
         <Typography variant="subtitle1">Choose your setup</Typography>
@@ -105,37 +125,44 @@ export function ChallengeSetupDialog(props: LevelDialogProps) {
           <FormControl>
             <FormLabel id="rounds-label">Rounds</FormLabel>
             <RadioGroup
+              row
               name="rounds"
               aria-label="rounds"
-              value={formik.values.rounds}
-              onChange={formik.handleChange}
+              value={roundsController}
+              onChange={(e) => setRoundsController(e.target.value)}
             >
               {ROUNDS_ARRAY.map((r) => (
                 <FormControlLabel
                   key={r}
                   value={r}
                   control={<Radio size="small" />}
-                  label={r === 20 ? "Custom" : r}
+                  label={r}
                 />
               ))}
+              <FormControlLabel
+                key="custom"
+                value="custom"
+                control={<Radio size="small" />}
+                label="Custom"
+              />
             </RadioGroup>
           </FormControl>
-          {/* {selectedRounds === 20 && ( */}
-          <TextField
-            error={Boolean(formik.touched.rounds && formik.errors.rounds)}
-            helperText={formik.touched.rounds && formik.errors.rounds}
-            fullWidth
-            label="Custom rounds"
-            margin="normal"
-            name="rounds"
-            aria-label="rounds"
-            onBlur={formik.handleBlur}
-            onChange={formik.handleChange}
-            value={formik.values.rounds}
-            variant="outlined"
-            type="number"
-          />
-          {/* )} */}
+          {customRoundsInput && (
+            <TextField
+              error={Boolean(formik.touched.rounds && formik.errors.rounds)}
+              helperText={formik.touched.rounds && formik.errors.rounds}
+              fullWidth
+              label="Custom rounds"
+              margin="normal"
+              name="rounds"
+              aria-label="rounds"
+              onBlur={formik.handleBlur}
+              onChange={formik.handleChange}
+              value={formik.values.rounds}
+              variant="outlined"
+              type="number"
+            />
+          )}
           <FormControl>
             <FormLabel id="level-label">Level</FormLabel>
             <RadioGroup

--- a/src/molecules/ChallengeSetupDialog/ChallengeSetupDialog.tsx
+++ b/src/molecules/ChallengeSetupDialog/ChallengeSetupDialog.tsx
@@ -26,6 +26,7 @@ export interface LevelDialogProps {
 }
 
 const LEVELS_COUNT = 5
+const ROUNDS_ARRAY = [5, 10, 15, 20]
 
 export function ChallengeSetupDialog(props: LevelDialogProps) {
   const { onClose, setup, open } = props
@@ -101,11 +102,30 @@ export function ChallengeSetupDialog(props: LevelDialogProps) {
               />
             </>
           )}
+          <FormControl>
+            <FormLabel id="rounds-label">Rounds</FormLabel>
+            <RadioGroup
+              name="rounds"
+              aria-label="rounds"
+              value={formik.values.rounds}
+              onChange={formik.handleChange}
+            >
+              {ROUNDS_ARRAY.map((r) => (
+                <FormControlLabel
+                  key={r}
+                  value={r}
+                  control={<Radio size="small" />}
+                  label={r === 20 ? "Custom" : r}
+                />
+              ))}
+            </RadioGroup>
+          </FormControl>
+          {/* {selectedRounds === 20 && ( */}
           <TextField
             error={Boolean(formik.touched.rounds && formik.errors.rounds)}
             helperText={formik.touched.rounds && formik.errors.rounds}
             fullWidth
-            label="Rounds"
+            label="Custom rounds"
             margin="normal"
             name="rounds"
             aria-label="rounds"
@@ -115,6 +135,7 @@ export function ChallengeSetupDialog(props: LevelDialogProps) {
             variant="outlined"
             type="number"
           />
+          {/* )} */}
           <FormControl>
             <FormLabel id="level-label">Level</FormLabel>
             <RadioGroup

--- a/src/molecules/ChallengeSetupDialog/ChallengeSetupDialog.tsx
+++ b/src/molecules/ChallengeSetupDialog/ChallengeSetupDialog.tsx
@@ -18,6 +18,7 @@ import * as Yup from "yup"
 import { Box } from "@mui/system"
 import { ChallengeSetup } from "../../types/challenge"
 import React, { useEffect, useMemo, useState } from "react"
+import { defaultRounds } from "../../utils/constants"
 
 export interface LevelDialogProps {
   open: boolean
@@ -59,13 +60,15 @@ export function ChallengeSetupDialog(props: LevelDialogProps) {
     [formik]
   )
 
-  const [roundsController, setRoundsController] = useState<number | string>(10)
+  const [roundsController, setRoundsController] = useState<number | string>(
+    defaultRounds
+  )
   const [customRoundsInput, setCustomRoundsInput] = useState<boolean>(false)
 
   useEffect(() => {
     if (roundsController === "custom") {
       setCustomRoundsInput(true)
-      formik.setFieldValue("rounds", 10)
+      formik.setFieldValue("rounds", defaultRounds)
     } else {
       setCustomRoundsInput(false)
       formik.setFieldValue("rounds", roundsController)
@@ -123,10 +126,10 @@ export function ChallengeSetupDialog(props: LevelDialogProps) {
             </>
           )}
           <FormControl>
-            <FormLabel id="rounds-label">Rounds</FormLabel>
+            <FormLabel id="rounds-controller-label">Rounds</FormLabel>
             <RadioGroup
               row
-              name="rounds"
+              name="roundsController"
               aria-label="rounds-controller"
               value={roundsController}
               onChange={(e) => setRoundsController(e.target.value)}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,6 +4,8 @@ export const maxLevels = 5
 
 export const maxHints = 3
 
+export const defaultRounds = 10
+
 export type ChallengeStatus = "pending" | "started" | "finished" | "aborted"
 
 export const defaultUserSettings: UserSettings = {}


### PR DESCRIPTION
- Fixed options for round numbers `5 | 10 | 15 | custom` is given on game setup window
- Options are shown as radio buttons
- `Custom rounds` input is hidden by default
- Choosing custom shows the `Custom rounds` input where user can input any number between `2` and `100`
- Switching to `5 | 10 | 15` value in rounds radio group makes the Custom rounds input hidden
- Input values are saved in game configuration and the number of rounds is given according to the setup
- Tests are added to the [spreadsheet](https://docs.google.com/spreadsheets/d/1bfFrEOOUulLGaZTeHJjW62BI0UeyGGayOMGzeVReHUk/edit#gid=1307178696)